### PR TITLE
fix typo, add safety to build script

### DIFF
--- a/Resources/tooltips.xml
+++ b/Resources/tooltips.xml
@@ -2,7 +2,7 @@
 
 <tooltips>
 	<param id="idInputLevel">
-		Use to gain stage the guitar singal. A lightly strummed open chord should peak just above the "S" level for a single coil pickup, or "H" for humbucker pickup.
+		Use to gain stage the guitar signal. A lightly strummed open chord should peak just above the "S" level for a single coil pickup, or "H" for humbucker pickup.
 	</param>
 	<param id="idOutputLevel">
 		Use to gain stage the overall plugin master volume. This affects only how loud the plugin will sound.

--- a/package/build-mac.sh
+++ b/package/build-mac.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 cp ../Resources/dmg-bg.png dmg-vst3/.bg.png
 cp ../Resources/dmg-bg.png dmg-au/.bg.png
@@ -9,7 +10,7 @@ cp -r ../Builds/MacOSX/build/Release/SwankyAmp.component dmg-au/
 hdiutil create -fs "Case-sensitive Journaled HFS+" -format UDRW -srcfolder dmg-vst3 dmg-vst3.dmg
 hdiutil create -fs "Case-sensitive Journaled HFS+" -format UDRW -srcfolder dmg-au dmg-au.dmg
 
-read -n 1 -p "Set DMG style then press any key to continue"
+read -r -n 1 -p "Set DMG style then press any key to continue"
 
 hdiutil convert -format UDRO -o SwankyAmp-vst3.dmg dmg-vst3.dmg
 hdiutil convert -format UDRO -o SwankyAmp-au.dmg dmg-au.dmg


### PR DESCRIPTION
Noticed a typo in one of the tooltips. Also added `set -e` to exit the mac build script on error, and `-r` to avoid mangling backslashes.